### PR TITLE
Leaflet does not support disableScrollPropagation

### DIFF
--- a/src/leaflet-categorized-layers.js
+++ b/src/leaflet-categorized-layers.js
@@ -240,8 +240,7 @@ L.Control.CategorizedLayers = L.Control.Layers.extend({
 
     if (!L.Browser.touch) {
       L.DomEvent
-        .disableClickPropagation(container)
-        .disableScrollPropagation(container);
+        .disableClickPropagation(container);
     } else {
       L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
     }


### PR DESCRIPTION
Hi

Leaflet does not seem to expose a DomEvent.disableScrollPropagation method (anymore). Would it be reasonable to remove it?

Regards,
Jesper
